### PR TITLE
Add {{fileType}} to filenameFormat options (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ This setup exempts many options so they will use default values _(see below)_. I
     "presenceStatus": "dnd",
     "presenceType": 3,
     "presenceOverwrite": "{{count}} files",
+    "filenameFormat": "{{date}} {{file}}",
     "filenameDateFormat": "2006.01.02-15.04.05 ",
     "embedColor": "#EE22CC",
     "inflateCount": 12345,
@@ -408,6 +409,7 @@ This setup exempts many options so they will use default values _(see below)_. I
     "presenceOverwrite": "{{count}} things",
     "presenceOverwriteDetails": "these are my details",
     "presenceOverwriteState": "this is my state",
+    "filenameFormat": "{{date}} {{file}}",
     "filenameDateFormat": "2006.01.02_15.04.05_",
     "embedColor": "#FF0000",
     "inflateCount": 69,
@@ -705,6 +707,10 @@ This setup exempts many options so they will use default values _(see below)_. I
         * _Default:_ `true`
         * Confirmation reaction that file(s) successfully downloaded. Is overwritten by the channel/server equivelant of this setting.
 ---
+* :small_blue_diamond: "filenameFormat"
+    * — _settings.filenameFormat : string_
+    * _Default:_ `"{{date}} {{file}}"`
+    * `"{{date}}"`, `"{{file}}"`, `"{{messageID}}"`, `"{{userID}}"`, `"{{username}}"`, `"{{channelID}}"`, `"{{serverID}}"`, `"{{message}}"`, `"{{fileType}}"`
 * :small_blue_diamond: "filenameDateFormat"
     * — _settings.filenameDateFormat : string_
     * _Default:_ `"2006-01-02_15-04-05 "`

--- a/discord.go
+++ b/discord.go
@@ -164,6 +164,7 @@ func filenameKeyReplacement(channelConfig configurationChannel, download downloa
 		keys := [][]string{
 			{"{{date}}", messageTime.Format(filenameDateFormat)},
 			{"{{file}}", download.Filename},
+			{"{{fileType}}", download.FileExtension},
 			{"{{messageID}}", download.Message.ID},
 			{"{{userID}}", download.Message.Author.ID},
 			{"{{username}}", download.Message.Author.Username},

--- a/downloads.go
+++ b/downloads.go
@@ -415,6 +415,7 @@ func getFileLinks(m *discordgo.Message) []*fileItem {
 type downloadRequestStruct struct {
 	InputURL       string
 	Filename       string
+	FileExtension  string
 	Path           string
 	Message        *discordgo.Message
 	FileTime       time.Time
@@ -689,6 +690,7 @@ func tryDownload(download downloadRequestStruct) downloadStatusStruct {
 		}
 
 		extension := strings.ToLower(filepath.Ext(download.Filename))
+		download.FileExtension = extension
 
 		contentType := http.DetectContentType(bodyOfResp)
 		contentTypeParts := strings.Split(contentType, "/")
@@ -744,6 +746,7 @@ func tryDownload(download downloadRequestStruct) downloadStatusStruct {
 			possibleExtension, _ := mime.ExtensionsByType(contentType)
 			if len(possibleExtension) > 0 {
 				download.Filename += possibleExtension[0]
+				download.FileExtension = possibleExtension[0]
 			}
 		}
 


### PR DESCRIPTION
- Add `FileExtension` to `downloadRequestStruct`
- Make `FileExtensions` in `downloadRequestStruct` usable with ``{{fileType}}`` in filenameFormat options
- Update `README.md` with `filenameFormat` settings

This would close #65 
