### PR TITLE
Add nanoId and shortId as a unique string generators to use with filenameFormat

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/fatih/color"
 	"github.com/hako/durafmt"
+	"github.com/teris-io/shortid"
 )
 
 const (
@@ -162,6 +163,11 @@ func filenameKeyReplacement(channelConfig configurationChannel, download downloa
 			}
 		}
 
+		shortId, err := shortid.Generate()
+		if err != nil {
+			log.Println(logPrefixDebug, color.HiCyanString("Error when generating a shortId %s", err))
+		}
+
 		nanoId, err := nanoid.New()
 		if err != nil {
 			log.Println(logPrefixDebug, color.HiCyanString("Error when creating a nanoid %s", err))
@@ -177,6 +183,7 @@ func filenameKeyReplacement(channelConfig configurationChannel, download downloa
 			{"{{serverID}}", download.Message.GuildID},
 			{"{{message}}", clearPath(download.Message.Content)},
 			{"{{nanoId}}", nanoId},
+			{"{{shortId}}", shortId},
 		}
 		for _, key := range keys {
 			if strings.Contains(ret, key[0]) {

--- a/discord.go
+++ b/discord.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/AvraamMavridis/randomcolor"
+	"github.com/aidarkhanov/nanoid/v2"
 	"github.com/bwmarrin/discordgo"
 	"github.com/fatih/color"
 	"github.com/hako/durafmt"
@@ -161,6 +162,11 @@ func filenameKeyReplacement(channelConfig configurationChannel, download downloa
 			}
 		}
 
+		nanoUid, err := nanoid.New()
+		if err != nil {
+			log.Println(logPrefixDebug, color.HiCyanString("Error when creating a nanoid %s", err))
+		}
+
 		keys := [][]string{
 			{"{{date}}", messageTime.Format(filenameDateFormat)},
 			{"{{file}}", download.Filename},
@@ -170,6 +176,7 @@ func filenameKeyReplacement(channelConfig configurationChannel, download downloa
 			{"{{channelID}}", download.Message.ChannelID},
 			{"{{serverID}}", download.Message.GuildID},
 			{"{{message}}", clearPath(download.Message.Content)},
+			{"{{nanoUid}}", nanoUid},
 		}
 		for _, key := range keys {
 			if strings.Contains(ret, key[0]) {

--- a/discord.go
+++ b/discord.go
@@ -162,7 +162,7 @@ func filenameKeyReplacement(channelConfig configurationChannel, download downloa
 			}
 		}
 
-		nanoUid, err := nanoid.New()
+		nanoId, err := nanoid.New()
 		if err != nil {
 			log.Println(logPrefixDebug, color.HiCyanString("Error when creating a nanoid %s", err))
 		}
@@ -176,7 +176,7 @@ func filenameKeyReplacement(channelConfig configurationChannel, download downloa
 			{"{{channelID}}", download.Message.ChannelID},
 			{"{{serverID}}", download.Message.GuildID},
 			{"{{message}}", clearPath(download.Message.Content)},
-			{"{{nanoUid}}", nanoUid},
+			{"{{nanoId}}", nanoId},
 		}
 		for _, key := range keys {
 			if strings.Contains(ret, key[0]) {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Jeffail/gabs v1.4.0
 	github.com/Necroforger/dgrouter v0.0.0-20200517224846-e66453b957c1
 	github.com/PuerkitoBio/goquery v1.6.1
+	github.com/aidarkhanov/nanoid/v2 v2.0.5
 	github.com/azr/backoff v0.0.0-20160115115103-53511d3c7330 // indirect
 	github.com/bwmarrin/discordgo v0.22.0
 	github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc // indirect
@@ -30,6 +31,4 @@ require (
 	mvdan.cc/xurls/v2 v2.2.0
 )
 
-replace (
-    github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.1
-)
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/muhammadmuzzammil1998/jsonc v0.0.0-20201229145248-615b0916ca38
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/rivo/duplo v0.0.0-20180323201418-c4ec823d58cd
+	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569
 	golang.org/x/net v0.0.0-20210505214959-0714010a04ed
 	golang.org/x/oauth2 v0.0.0-20210427180440-81ed05c6b58c
 	google.golang.org/api v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569 h1:xzABM9let0HLLqFypcxvLmlvEciCHL7+Lv+4vwZqecI=
+github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569/go.mod h1:2Ly+NIftZN4de9zRmENdYbvPQeaVIYKWpLFStLFEBgI=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/Necroforger/dgrouter v0.0.0-20200517224846-e66453b957c1 h1:3OHJOlf0r1
 github.com/Necroforger/dgrouter v0.0.0-20200517224846-e66453b957c1/go.mod h1:FdMxPfOp4ppZW2OJjLagSMri7g5k9luvTm7Y3aIxQSc=
 github.com/PuerkitoBio/goquery v1.6.1 h1:FgjbQZKl5HTmcn4sKBgvx8vv63nhyhIpv7lJpFGCWpk=
 github.com/PuerkitoBio/goquery v1.6.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
+github.com/aidarkhanov/nanoid/v2 v2.0.5 h1:HLx5RyDuvOZ6YxlhYTxSU8Il+q7xVKmXM62MfSxziN0=
+github.com/aidarkhanov/nanoid/v2 v2.0.5/go.mod h1:YF/U48D1yA3AoGGUdRrCV95J/KJBShvR9TyLqQwdtlI=
 github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/azr/backoff v0.0.0-20160115115103-53511d3c7330 h1:ekDALXAVvY/Ub1UtNta3inKQwZ/jMB/zpOtD8rAYh78=


### PR DESCRIPTION
[nanoId](https://github.com/aidarkhanov/nanoid) and [shortId ](https://github.com/teris-io/shortid) offer simple ways to generate unique strings, this could help with generating unique filenames

Notably this would fix #67 as every attachment would have a unique filename, [and make duplicate file naming easier](https://discord.com/channels/780985109608005703/780989998064730213/1014152496819748955), **assuming** a unique string generator is used
![image](https://user-images.githubusercontent.com/5809130/190873490-fe43800b-6a16-4f32-8017-e2757999e285.png)

- Add `{{nanoId}}` as a new option for filenameFormat, example: i25_rX9zwDdDn7Sg-ZoaH
- Add `{{shortId}}` as a new option for filenameFormat, example: NVovc6-QQy

Note: It may not be the best idea to pre-generate these unique strings before it's even needed. Currently in this implemenation it'll generate a nanoId or shortId even if {{nanoId}} or {{shortId}} aren't present, it just won't use them. It shouldn't be an issue ever, but it's worth mentioning.

We could also change the default filenameFormat to something like {{date}} {{shortId}} {{file}} to create short, unique, and sortable file saving. On top of this with the automatic filename trimming, only the filename from the download would ever be cut short, guaranteeing files always be unique by default.

This would close #66 