### PR TITLE
Use shortID in the default filenameFormat 

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,8 @@ This setup exempts many options so they will use default values _(see below)_. I
     * — _settings.filenameFormat : string_
     * _Default:_ `"{{date}} {{file}}"`
     * `"{{date}}"`, `"{{file}}"`, `"{{messageID}}"`, `"{{userID}}"`, `"{{username}}"`, `"{{channelID}}"`, `"{{serverID}}"`, `"{{message}}"`, `"{{fileType}}"`, `"{{nanoID}}"`, `"{{shortID}}"`
+    * `"{{nanoID}}"` is a 21 character unique string, eg: i25_rX9zwDdDn7Sg-ZoaH
+    * `"{{shortID}}"` is a short unique string, eg: NVovc6-QQy
 * :small_blue_diamond: "filenameDateFormat"
     * — _settings.filenameDateFormat : string_
     * _Default:_ `"2006-01-02_15-04-05 "`

--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ This setup exempts many options so they will use default values _(see below)_. I
 * :small_blue_diamond: "filenameFormat"
     * — _settings.filenameFormat : string_
     * _Default:_ `"{{date}} {{file}}"`
-    * `"{{date}}"`, `"{{file}}"`, `"{{messageID}}"`, `"{{userID}}"`, `"{{username}}"`, `"{{channelID}}"`, `"{{serverID}}"`, `"{{message}}"`, `"{{fileType}}"`
+    * `"{{date}}"`, `"{{file}}"`, `"{{messageID}}"`, `"{{userID}}"`, `"{{username}}"`, `"{{channelID}}"`, `"{{serverID}}"`, `"{{message}}"`, `"{{fileType}}"`, `"{{nanoID}}"`, `"{{shortID}}"`
 * :small_blue_diamond: "filenameDateFormat"
     * — _settings.filenameDateFormat : string_
     * _Default:_ `"2006-01-02_15-04-05 "`

--- a/config.go
+++ b/config.go
@@ -96,7 +96,7 @@ func defaultConfiguration() configuration {
 		PresenceType:         cdPresenceType,
 		ReactWhenDownloaded:  cdReactWhenDownloaded,
 		FilenameDateFormat:   "2006-01-02_15-04-05",
-		FilenameFormat:       "{{date}} {{file}}",
+		FilenameFormat:       "{{date}} {{shortID}} {{file}}",
 		InflateCount:         &cdInflateCount,
 		NumberFormatEuropean: false,
 	}


### PR DESCRIPTION
This creates a short, unique, and sortable file when saving by default. On top of this with the automatic filename trimming, only the filename from the download would ever be cut short, guaranteeing files always be unique by default.

- Change default filenameFormat to `{{date}} {{shortId}} {{file}}`